### PR TITLE
Make ssh-add / ssh-agent optional (for the generator)

### DIFF
--- a/command/atp
+++ b/command/atp
@@ -67,8 +67,10 @@ export IMAGE_VERSION=${IMAGE_VERSION:-'0.0.0'}
 
 {
     eval "$(${TRITON} env --smartdc --triton)"
-    eval "$(${SSH_AGENT})"
-    ${SSH_ADD}
+    if test -z  "${SSH_PRIVATE_KEY_FILE:-}" ; then
+        eval "$(${SSH_AGENT})"
+        ${SSH_ADD}
+    fi
 } 1>/dev/null 2>/dev/null
 
 triton_account()


### PR DESCRIPTION
This makes it possible to *not* run `ssh-add` if the user has a specific ssh key file in mind.  This is necessary if `ssh-add` would fail (for example, because `~/.ssh/id_rsa` etc. doesn't exist).

Fixes #1